### PR TITLE
throw IllegalArgumentException for zero or negative durations

### DIFF
--- a/omnipod/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/driver/communication/message/command/TempBasalExtraCommand.java
+++ b/omnipod/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/driver/communication/message/command/TempBasalExtraCommand.java
@@ -27,7 +27,10 @@ public class TempBasalExtraCommand extends MessageBlock {
         } else if (rate > OmnipodConstants.MAX_BASAL_RATE) {
             throw new IllegalArgumentException("Rate exceeds max basal rate");
         }
-        if (duration.isLongerThan(OmnipodConstants.MAX_TEMP_BASAL_DURATION)) {
+
+        if (duration.isShorterThan(Duration.ZERO) || duration.equals(Duration.ZERO)) {
+            throw new IllegalArgumentException("Duration should be > 0");
+        } else if (duration.isLongerThan(OmnipodConstants.MAX_TEMP_BASAL_DURATION)) {
             throw new IllegalArgumentException("Duration exceeds max temp basal duration");
         }
 


### PR DESCRIPTION
This adds a sanity check on durations for TBRs in the command TempBasalExtraCommand:

if duration is negative or zero, we throw an IllegalArgumentException