### PR TITLE
Return programmed duration and rate when setting TBR, fixes AAPS-Omni…

### DIFF
--- a/omnipod/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/manager/AapsOmnipodManager.java
+++ b/omnipod/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/manager/AapsOmnipodManager.java
@@ -481,7 +481,10 @@ public class AapsOmnipodManager {
 
         addTempBasalTreatment(System.currentTimeMillis(), pumpId, tempBasalPair);
 
-        return new PumpEnactResult(injector).success(true).enacted(true);
+        return new PumpEnactResult(injector)
+                .duration(tempBasalPair.getDurationMinutes())
+                .absolute(PumpType.Insulet_Omnipod.determineCorrectBasalSize(tempBasalPair.getInsulinRate()))
+                .success(true).enacted(true);
     }
 
     public PumpEnactResult cancelTemporaryBasal() {


### PR DESCRIPTION
Correct treatment dosage and duration in response when setting temporary basal rate

These response values are e.g. shown in response messages when setting a TBR via SMS.

Fixes AAPS-Omnipod/AndroidAPS#12