### PR TITLE
Added getting RileyLink battery level

### DIFF
--- a/omnipod/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/OmnipodPumpPlugin.java
+++ b/omnipod/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/OmnipodPumpPlugin.java
@@ -611,10 +611,7 @@ public class OmnipodPumpPlugin extends PumpPluginBase implements PumpInterface, 
 
     @Override
     public int getBatteryLevel() {
-        if (!podStateManager.isPodRunning()) {
-            return 0;
-        }
-        return 75;
+        return rileyLinkServiceData.batteryLevel == null ? 0 : rileyLinkServiceData.batteryLevel;
     }
 
     @NonNull @Override
@@ -738,9 +735,7 @@ public class OmnipodPumpPlugin extends PumpPluginBase implements PumpInterface, 
 
             status.put("timestamp", DateUtil.toISOString(new Date()));
 
-            // BS: Leave battery level out for now as we only have a fixed bogus value
-            // TODO use RL battery level
-            //pump.put("battery", battery);
+            pump.put("battery", battery);
 
             pump.put("status", status);
             pump.put("extended", extended);
@@ -804,10 +799,7 @@ public class OmnipodPumpPlugin extends PumpPluginBase implements PumpInterface, 
             ret += "Extended: " + activeExtendedBolus.toString() + "\n";
         }
         ret += "Reserv: " + (getReservoirLevel() > OmnipodConstants.MAX_RESERVOIR_READING ? "50+U" : DecimalFormatter.to0Decimal(getReservoirLevel()) + "U") + "\n";
-
-        // BS leave out for now as we only have a bogus default value
-        // TODO use RL battery
-        // ret += "Batt: " + getBatteryLevel();
+        ret += "Batt: " + getBatteryLevel();
 
         return ret.trim();
     }

--- a/omnipod/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/OmnipodPumpPlugin.java
+++ b/omnipod/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/OmnipodPumpPlugin.java
@@ -119,6 +119,7 @@ public class OmnipodPumpPlugin extends PumpPluginBase implements PumpInterface, 
     private static final long STATUS_CHECK_INTERVAL_MILLIS = 60 * 1000L; // 1 minute
     public static final int STARTUP_STATUS_REQUEST_TRIES = 2;
     public static final double RESERVOIR_OVER_50_UNITS_DEFAULT = 75.0;
+    private static final int DEFAULT_BATTERY_LEVEL = 75;
 
     private final PodStateManager podStateManager;
     private final RileyLinkServiceData rileyLinkServiceData;
@@ -311,7 +312,8 @@ public class OmnipodPumpPlugin extends PumpPluginBase implements PumpInterface, 
                             event.isChanged(getResourceHelper(), OmnipodStorageKeys.Preferences.SMB_BEEPS_ENABLED) ||
                             event.isChanged(getResourceHelper(), OmnipodStorageKeys.Preferences.SUSPEND_DELIVERY_BUTTON_ENABLED) ||
                             event.isChanged(getResourceHelper(), OmnipodStorageKeys.Preferences.PULSE_LOG_BUTTON_ENABLED) ||
-                            event.isChanged(getResourceHelper(), OmnipodStorageKeys.Preferences.RILEYLINK_STATS_BUTTON_ENABLED) ||
+                            event.isChanged(getResourceHelper(), OmnipodStorageKeys.Preferences.RILEY_LINK_STATS_BUTTON_ENABLED) ||
+                            event.isChanged(getResourceHelper(), OmnipodStorageKeys.Preferences.USE_RILEY_LINK_BATTERY_LEVEL) ||
                             event.isChanged(getResourceHelper(), OmnipodStorageKeys.Preferences.TIME_CHANGE_EVENT_ENABLED) ||
                             event.isChanged(getResourceHelper(), OmnipodStorageKeys.Preferences.NOTIFICATION_UNCERTAIN_TBR_SOUND_ENABLED) ||
                             event.isChanged(getResourceHelper(), OmnipodStorageKeys.Preferences.NOTIFICATION_UNCERTAIN_SMB_SOUND_ENABLED) ||
@@ -611,7 +613,11 @@ public class OmnipodPumpPlugin extends PumpPluginBase implements PumpInterface, 
 
     @Override
     public int getBatteryLevel() {
-        return rileyLinkServiceData.batteryLevel == null ? 0 : rileyLinkServiceData.batteryLevel;
+        if (aapsOmnipodManager.isUseRileyLinkBatteryLevel()) {
+            return rileyLinkServiceData.batteryLevel == null ? 0 : rileyLinkServiceData.batteryLevel;
+        }
+
+        return DEFAULT_BATTERY_LEVEL;
     }
 
     @NonNull @Override

--- a/omnipod/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/definition/OmnipodStorageKeys.java
+++ b/omnipod/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/definition/OmnipodStorageKeys.java
@@ -21,7 +21,8 @@ public class OmnipodStorageKeys {
         public static final int NOTIFICATION_UNCERTAIN_SMB_SOUND_ENABLED = R.string.key_omnipod_notification_uncertain_smb_sound_enabled;
         public static final int NOTIFICATION_UNCERTAIN_BOLUS_SOUND_ENABLED = R.string.key_omnipod_notification_uncertain_bolus_sound_enabled;
         public static final int AUTOMATICALLY_ACKNOWLEDGE_ALERTS_ENABLED = R.string.key_omnipod_automatically_acknowledge_alerts_enabled;
-        public static final int RILEYLINK_STATS_BUTTON_ENABLED = R.string.key_omnipod_rileylink_stats_button_enabled;
+        public static final int RILEY_LINK_STATS_BUTTON_ENABLED = R.string.key_omnipod_riley_link_stats_button_enabled;
+        public static final int USE_RILEY_LINK_BATTERY_LEVEL = R.string.key_omnipod_use_riley_link_battery_level;
     }
 
     public static class Statistics {

--- a/omnipod/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/manager/AapsOmnipodManager.java
+++ b/omnipod/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/manager/AapsOmnipodManager.java
@@ -120,8 +120,8 @@ public class AapsOmnipodManager {
     private boolean notificationUncertainSmbSoundEnabled;
     private boolean notificationUncertainBolusSoundEnabled;
     private boolean automaticallyAcknowledgeAlertsEnabled;
-    private boolean testBeepButtonEnabled;
     private boolean rileylinkStatsButtonEnabled;
+    private boolean useRileyLinkBatteryLevel;
 
     @Inject
     public AapsOmnipodManager(OmnipodRileyLinkCommunicationManager communicationService,
@@ -165,7 +165,8 @@ public class AapsOmnipodManager {
         tbrBeepsEnabled = sp.getBoolean(OmnipodStorageKeys.Preferences.TBR_BEEPS_ENABLED, false);
         suspendDeliveryButtonEnabled = sp.getBoolean(OmnipodStorageKeys.Preferences.SUSPEND_DELIVERY_BUTTON_ENABLED, false);
         pulseLogButtonEnabled = sp.getBoolean(OmnipodStorageKeys.Preferences.PULSE_LOG_BUTTON_ENABLED, false);
-        rileylinkStatsButtonEnabled = sp.getBoolean(OmnipodStorageKeys.Preferences.RILEYLINK_STATS_BUTTON_ENABLED, false);
+        rileylinkStatsButtonEnabled = sp.getBoolean(OmnipodStorageKeys.Preferences.RILEY_LINK_STATS_BUTTON_ENABLED, false);
+        useRileyLinkBatteryLevel = sp.getBoolean(OmnipodStorageKeys.Preferences.USE_RILEY_LINK_BATTERY_LEVEL, false);
         timeChangeEventEnabled = sp.getBoolean(OmnipodStorageKeys.Preferences.TIME_CHANGE_EVENT_ENABLED, true);
         notificationUncertainTbrSoundEnabled = sp.getBoolean(OmnipodStorageKeys.Preferences.NOTIFICATION_UNCERTAIN_TBR_SOUND_ENABLED, false);
         notificationUncertainSmbSoundEnabled = sp.getBoolean(OmnipodStorageKeys.Preferences.NOTIFICATION_UNCERTAIN_SMB_SOUND_ENABLED, true);
@@ -655,12 +656,12 @@ public class AapsOmnipodManager {
         return pulseLogButtonEnabled;
     }
 
-    public boolean isTestBeepButtonEnabled() {
-        return testBeepButtonEnabled;
-    }
-
     public boolean isRileylinkStatsButtonEnabled() {
         return rileylinkStatsButtonEnabled;
+    }
+
+    public boolean isUseRileyLinkBatteryLevel() {
+        return useRileyLinkBatteryLevel;
     }
 
     public boolean isTimeChangeEventEnabled() {

--- a/omnipod/src/main/res/values/strings.xml
+++ b/omnipod/src/main/res/values/strings.xml
@@ -10,7 +10,8 @@
     <string name="key_omnipod_tbr_beeps_enabled" translatable="false">AAPS.Omnipod.tbr_beeps_enabled</string>
     <string name="key_omnipod_suspend_delivery_button_enabled" translatable="false">AAPS.Omnipod.suspend_delivery_button_enabled</string>
     <string name="key_omnipod_pulse_log_button_enabled" translatable="false">AAPS.Omnipod.pulse_log_button_enabled</string>
-    <string name="key_omnipod_rileylink_stats_button_enabled" translatable="false">AAPS.Omnipod.rileylink_stats_button_enabled</string>
+    <string name="key_omnipod_riley_link_stats_button_enabled" translatable="false">AAPS.Omnipod.rileylink_stats_button_enabled</string>
+    <string name="key_omnipod_use_riley_link_battery_level" translatable="false">AAPS.Omnipod.use_riley_link_battery_level</string>
     <string name="key_omnipod_time_change_event_enabled" translatable="false">AAPS.Omnipod.time_change_enabled</string>
     <string name="key_omnipod_expiration_reminder_enabled" translatable="false">AAPS.Omnipod.expiration_reminder_enabled</string>
     <string name="key_omnipod_expiration_reminder_hours_before_shutdown" translatable="false">AAPS.Omnipod.expiration_reminder_hours_before_shutdown</string>
@@ -43,6 +44,8 @@
     <string name="omnipod_config_suspend_delivery_button_enabled">Show Suspend Delivery button in Omnipod tab</string>
     <string name="omnipod_config_pulse_log_button_enabled">Show Pulse Log button in Pod Management menu</string>
     <string name="omnipod_config_rileylink_stats_button_enabled">Show RileyLink Stats button in Pod Management menu</string>
+    <string name="omnipod_config_use_riley_link_battery_level">Use battery level reported by RileyLink (experimental)</string>
+    <string name="omnipod_config_use_riley_link_battery_level_summary">Only tested with EmaLink. The reported battery level may be inaccurate with other devices.\nWhen disabled, the battery level show a fixed value of 75.</string>
     <string name="omnipod_config_time_change_enabled">DST/Time zone detection enabled</string>
     <string name="omnipod_config_expiration_reminder_enabled">Expiration reminder enabled</string>
     <string name="omnipod_config_expiration_reminder_hours_before_shutdown">Hours before shutdown</string>

--- a/omnipod/src/main/res/values/strings.xml
+++ b/omnipod/src/main/res/values/strings.xml
@@ -44,8 +44,8 @@
     <string name="omnipod_config_suspend_delivery_button_enabled">Show Suspend Delivery button in Omnipod tab</string>
     <string name="omnipod_config_pulse_log_button_enabled">Show Pulse Log button in Pod Management menu</string>
     <string name="omnipod_config_rileylink_stats_button_enabled">Show RileyLink Stats button in Pod Management menu</string>
-    <string name="omnipod_config_use_riley_link_battery_level">Use battery level reported by RileyLink (experimental)</string>
-    <string name="omnipod_config_use_riley_link_battery_level_summary">Only tested with EmaLink. The reported battery level may be inaccurate with other devices.\nWhen disabled, the battery level show a fixed value of 75.</string>
+    <string name="omnipod_config_use_riley_link_battery_level">Use battery level reported by RileyLink</string>
+    <string name="omnipod_config_use_riley_link_battery_level_summary">Works with EmaLink and OrangeLink.\nDOES NOT work with the original RileyLink: it will not report the actual battery level. Might also not work with other RileyLink alternatives.</string>
     <string name="omnipod_config_time_change_enabled">DST/Time zone detection enabled</string>
     <string name="omnipod_config_expiration_reminder_enabled">Expiration reminder enabled</string>
     <string name="omnipod_config_expiration_reminder_hours_before_shutdown">Hours before shutdown</string>
@@ -90,6 +90,15 @@
     <string name="omnipod_history_bolus_value">%1$.2f U</string>
     <string name="omnipod_history_bolus_value_with_carbs">%1$.2f U, CH=%2$.1f g</string>
     <string name="omnipod_history_tbr_value">Rate: %1$.2f U, duration: %2$d minutes</string>
+
+    <!-- Omnipod - Short status -->
+    <string name="omnipod_short_status_no_active_pod">No active Pod</string>
+    <string name="omnipod_short_status_last_connection">LastConn: %1$d min ago</string>
+    <string name="omnipod_short_status_last_bolus">LastBolus: %1$s @ %2$s</string>
+    <string name="omnipod_short_status_temp_basal">Temp: %1$s</string>
+    <string name="omnipod_short_status_extended_bolus">Extended: %1$s</string>
+    <string name="omnipod_short_status_reservoir">Reserv: %1$sU</string>
+    <string name="omnipod_short_status_rl_battery">RLBatt: %1$d</string>
 
     <!-- Omnipod - Error -->
     <string name="omnipod_warning">Warning</string>

--- a/omnipod/src/main/res/xml/pref_omnipod.xml
+++ b/omnipod/src/main/res/xml/pref_omnipod.xml
@@ -112,8 +112,14 @@
 
         <SwitchPreference
             android:defaultValue="false"
-            android:key="@string/key_omnipod_rileylink_stats_button_enabled"
+            android:key="@string/key_omnipod_riley_link_stats_button_enabled"
             android:title="@string/omnipod_config_rileylink_stats_button_enabled" />
+
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="@string/key_omnipod_use_riley_link_battery_level"
+            android:summary="@string/omnipod_config_use_riley_link_battery_level_summary"
+            android:title="@string/omnipod_config_use_riley_link_battery_level" />
 
         <SwitchPreference
             android:defaultValue="true"

--- a/rileylink/src/main/AndroidManifest.xml
+++ b/rileylink/src/main/AndroidManifest.xml
@@ -6,7 +6,6 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-    <uses-permission android:name="android.permission.SET_DEBUG_APP" />
 
     <application>
         <activity android:name=".dialog.RileyLinkBLEScanActivity">

--- a/rileylink/src/main/AndroidManifest.xml
+++ b/rileylink/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.SET_DEBUG_APP" />
 
     <application>
         <activity android:name=".dialog.RileyLinkBLEScanActivity">

--- a/rileylink/src/main/java/info/nightscout/androidaps/plugins/pump/common/hw/rileylink/RileyLinkCommunicationManager.java
+++ b/rileylink/src/main/java/info/nightscout/androidaps/plugins/pump/common/hw/rileylink/RileyLinkCommunicationManager.java
@@ -81,6 +81,8 @@ public abstract class RileyLinkCommunicationManager<T extends RLMessage> {
         RadioResponse radioResponse = rfSpyResponse.getRadioResponse(injector);
         T response = createResponseMessage(radioResponse.getPayload());
 
+        updateBatteryLevel();
+
         if (response.isValid()) {
             // Mark this as the last time we heard from the pump.
             rememberLastGoodDeviceCommunicationTime();
@@ -114,6 +116,10 @@ public abstract class RileyLinkCommunicationManager<T extends RLMessage> {
         }
 
         return response;
+    }
+
+    private void updateBatteryLevel() {
+        rileyLinkServiceData.batteryLevel = rfspy.getBatteryLevel();
     }
 
 

--- a/rileylink/src/main/java/info/nightscout/androidaps/plugins/pump/common/hw/rileylink/ble/RFSpy.java
+++ b/rileylink/src/main/java/info/nightscout/androidaps/plugins/pump/common/hw/rileylink/ble/RFSpy.java
@@ -57,6 +57,8 @@ public class RFSpy {
     private final UUID radioServiceUUID = UUID.fromString(GattAttributes.SERVICE_RADIO);
     private final UUID radioDataUUID = UUID.fromString(GattAttributes.CHARA_RADIO_DATA);
     private final UUID radioVersionUUID = UUID.fromString(GattAttributes.CHARA_RADIO_VERSION);
+    private final UUID batteryServiceUUID = UUID.fromString(GattAttributes.SERVICE_BATTERY);
+    private final UUID batteryLevelUUID = UUID.fromString(GattAttributes.CHARA_BATTERY_UNK);
     //private UUID responseCountUUID = UUID.fromString(GattAttributes.CHARA_RADIO_RESPONSE_COUNT);
     private RileyLinkFirmwareVersion firmwareVersion;
     private String bleVersion; // We don't use it so no need of sofisticated logic
@@ -108,6 +110,19 @@ public class RFSpy {
     private void newDataIsAvailable() {
         // pass the message to the reader (which should be internal to RFSpy)
         reader.newDataIsAvailable();
+    }
+
+
+    public Integer getBatteryLevel() {
+        BLECommOperationResult result = rileyLinkBle.readCharacteristic_blocking(batteryServiceUUID, batteryLevelUUID);
+        if (result.resultCode == BLECommOperationResult.RESULT_SUCCESS) {
+            Integer value = (int) result.value[0];
+            aapsLogger.debug(LTag.PUMPBTCOMM, "BLE battery level: " + value.toString());
+            return value;
+        } else {
+            aapsLogger.error(LTag.PUMPBTCOMM, "getBatteryLevel failed with code: " + result.resultCode);
+            return -1;
+        }
     }
 
 
@@ -424,6 +439,8 @@ public class RFSpy {
      * Reset RileyLink Configuration (set all updateRegisters)
      */
     public void resetRileyLinkConfiguration() {
+        //TODO: Please move me to an appropriate place!
+        rileyLinkServiceData.batteryLevel = this.getBatteryLevel();
         if (this.currentFrequencyMHz != null)
             this.setBaseFrequency(this.currentFrequencyMHz);
     }

--- a/rileylink/src/main/java/info/nightscout/androidaps/plugins/pump/common/hw/rileylink/ble/RFSpy.java
+++ b/rileylink/src/main/java/info/nightscout/androidaps/plugins/pump/common/hw/rileylink/ble/RFSpy.java
@@ -116,12 +116,12 @@ public class RFSpy {
     public Integer getBatteryLevel() {
         BLECommOperationResult result = rileyLinkBle.readCharacteristic_blocking(batteryServiceUUID, batteryLevelUUID);
         if (result.resultCode == BLECommOperationResult.RESULT_SUCCESS) {
-            Integer value = (int) result.value[0];
-            aapsLogger.debug(LTag.PUMPBTCOMM, "BLE battery level: " + value.toString());
+            int value = result.value[0];
+            aapsLogger.debug(LTag.PUMPBTCOMM, "BLE battery level: {}", value);
             return value;
         } else {
             aapsLogger.error(LTag.PUMPBTCOMM, "getBatteryLevel failed with code: " + result.resultCode);
-            return -1;
+            return null;
         }
     }
 
@@ -439,8 +439,6 @@ public class RFSpy {
      * Reset RileyLink Configuration (set all updateRegisters)
      */
     public void resetRileyLinkConfiguration() {
-        //TODO: Please move me to an appropriate place!
-        rileyLinkServiceData.batteryLevel = this.getBatteryLevel();
         if (this.currentFrequencyMHz != null)
             this.setBaseFrequency(this.currentFrequencyMHz);
     }

--- a/rileylink/src/main/java/info/nightscout/androidaps/plugins/pump/common/hw/rileylink/dialog/RileyLinkStatusGeneralFragment.java
+++ b/rileylink/src/main/java/info/nightscout/androidaps/plugins/pump/common/hw/rileylink/dialog/RileyLinkStatusGeneralFragment.java
@@ -49,6 +49,7 @@ public class RileyLinkStatusGeneralFragment extends DaggerFragment implements Re
     TextView lastUsedFrequency;
     TextView lastDeviceContact;
     TextView firmwareVersion;
+    TextView batteryLevel;
 
     boolean first = false;
 
@@ -76,12 +77,14 @@ public class RileyLinkStatusGeneralFragment extends DaggerFragment implements Re
         this.lastUsedFrequency = getActivity().findViewById(R.id.rls_t1_last_used_frequency);
         this.lastDeviceContact = getActivity().findViewById(R.id.rls_t1_last_device_contact);
         this.firmwareVersion = getActivity().findViewById(R.id.rls_t1_firmware_version);
+        this.batteryLevel = getActivity().findViewById(R.id.rls_t1_battery_level);
 
         if (!first) {
 
-            // 7-12
+            // 7-14
             int[] ids = {R.id.rls_t1_tv02, R.id.rls_t1_tv03, R.id.rls_t1_tv04, R.id.rls_t1_tv05, R.id.rls_t1_tv07, //
-                    R.id.rls_t1_tv08, R.id.rls_t1_tv09, R.id.rls_t1_tv10, R.id.rls_t1_tv11, R.id.rls_t1_tv12, R.id.rls_t1_tv13};
+                    R.id.rls_t1_tv08, R.id.rls_t1_tv09, R.id.rls_t1_tv10, R.id.rls_t1_tv11, R.id.rls_t1_tv12, R.id.rls_t1_tv13,
+                    R.id.rls_t1_tv14};
 
             for (int id : ids) {
 
@@ -113,6 +116,12 @@ public class RileyLinkStatusGeneralFragment extends DaggerFragment implements Re
             } else {
                 this.firmwareVersion.setText("BLE113: " + rileyLinkServiceData.versionBLE113 +
                         "\nCC110: " + rileyLinkServiceData.versionCC110);
+            }
+            Integer batteryLevel = rileyLinkServiceData.batteryLevel;
+            if (batteryLevel == null || batteryLevel <= 0) {
+                this.batteryLevel.setText("???");
+            } else {
+                this.batteryLevel.setText(batteryLevel + "%");
             }
 
         }

--- a/rileylink/src/main/java/info/nightscout/androidaps/plugins/pump/common/hw/rileylink/dialog/RileyLinkStatusGeneralFragment.java
+++ b/rileylink/src/main/java/info/nightscout/androidaps/plugins/pump/common/hw/rileylink/dialog/RileyLinkStatusGeneralFragment.java
@@ -17,7 +17,6 @@ import info.nightscout.androidaps.interfaces.ActivePluginProvider;
 import info.nightscout.androidaps.logging.AAPSLogger;
 import info.nightscout.androidaps.plugins.pump.common.R;
 import info.nightscout.androidaps.plugins.pump.common.dialog.RefreshableInterface;
-import info.nightscout.androidaps.plugins.pump.common.hw.rileylink.ble.defs.RileyLinkFirmwareVersion;
 import info.nightscout.androidaps.plugins.pump.common.hw.rileylink.defs.RileyLinkPumpDevice;
 import info.nightscout.androidaps.plugins.pump.common.hw.rileylink.defs.RileyLinkPumpInfo;
 import info.nightscout.androidaps.plugins.pump.common.hw.rileylink.defs.RileyLinkTargetDevice;
@@ -118,7 +117,7 @@ public class RileyLinkStatusGeneralFragment extends DaggerFragment implements Re
                         "\nCC110: " + rileyLinkServiceData.versionCC110);
             }
             Integer batteryLevel = rileyLinkServiceData.batteryLevel;
-            if (batteryLevel == null || batteryLevel <= 0) {
+            if (batteryLevel == null) {
                 this.batteryLevel.setText("???");
             } else {
                 this.batteryLevel.setText(batteryLevel + "%");

--- a/rileylink/src/main/java/info/nightscout/androidaps/plugins/pump/common/hw/rileylink/service/RileyLinkServiceData.java
+++ b/rileylink/src/main/java/info/nightscout/androidaps/plugins/pump/common/hw/rileylink/service/RileyLinkServiceData.java
@@ -43,6 +43,7 @@ public class RileyLinkServiceData {
     // radio version
     public String versionCC110;
 
+    public Integer batteryLevel;
 
     public RileyLinkTargetDevice targetDevice;
 

--- a/rileylink/src/main/res/layout/rileylink_status_general.xml
+++ b/rileylink/src/main/res/layout/rileylink_status_general.xml
@@ -186,7 +186,6 @@
                     android:text="         " />
             </LinearLayout>
 
-
             <!-- Group - Device -->
             <LinearLayout
                 android:layout_width="match_parent"

--- a/rileylink/src/main/res/layout/rileylink_status_general.xml
+++ b/rileylink/src/main/res/layout/rileylink_status_general.xml
@@ -134,6 +134,31 @@
                     android:text="         " />
             </LinearLayout>
 
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="16pt"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/rls_t1_tv14"
+                    android:layout_width="58dp"
+                    android:layout_height="match_parent"
+                    android:layout_marginLeft="30dp"
+                    android:layout_weight="35"
+                    android:gravity="center_vertical"
+                    android:text="@string/rileylink_battery_level" />
+
+                <TextView
+                    android:id="@+id/rls_t1_battery_level"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:layout_marginLeft="10dp"
+                    android:layout_weight="65"
+                    android:textAlignment="center"
+                    android:gravity="center_vertical"
+                    android:text="         " />
+            </LinearLayout>
 
             <LinearLayout
                 android:layout_width="match_parent"
@@ -160,6 +185,7 @@
                     android:gravity="center_vertical"
                     android:text="         " />
             </LinearLayout>
+
 
             <!-- Group - Device -->
             <LinearLayout

--- a/rileylink/src/main/res/values/strings.xml
+++ b/rileylink/src/main/res/values/strings.xml
@@ -29,7 +29,8 @@
     <string name="rileylink_device_model">Device Model</string>
     <string name="rileylink_last_used_frequency">Last used frequency</string>
     <string name="rileylink_last_device_contact">Last device contact</string>
-    <string name="rileylink_firmware_version">RL Firmware</string>
+    <string name="rileylink_firmware_version">Firmware</string>
+    <string name="rileylink_battery_level">Battery level</string>
 
 
     <!-- RL State -->
@@ -64,7 +65,6 @@
     <string name="key_medtronic_encoding" translatable="false">pref_medtronic_encoding</string>
 
     <string name="mdt_last_bolus" translatable="false">%1$.1f %2$s (%3$s)</string>
-    <string name="rileylink_battery_level">RL Battery level</string>
 
     <plurals name="duration_days">
         <item quantity="one">%1$d day</item>

--- a/rileylink/src/main/res/values/strings.xml
+++ b/rileylink/src/main/res/values/strings.xml
@@ -64,6 +64,7 @@
     <string name="key_medtronic_encoding" translatable="false">pref_medtronic_encoding</string>
 
     <string name="mdt_last_bolus" translatable="false">%1$.1f %2$s (%3$s)</string>
+    <string name="rileylink_battery_level">RL Battery level</string>
 
     <plurals name="duration_days">
         <item quantity="one">%1$d day</item>


### PR DESCRIPTION
Please refactor the code so that battery level polling becomes safeguarded by a plugin setting (to be switched off for a standard RileyLink and switched on for EmaLink or other ones which really return battery level and put the call somewhere (maybe after each GetStatus Pod command)
Thanks and sorry I couldn't put the code in the proper place as I am not sure where to put it.